### PR TITLE
Fixes for example code (add a cabal target, fix compile error, fix connection error)

### DIFF
--- a/Grapevine.hs
+++ b/Grapevine.hs
@@ -101,7 +101,9 @@ grapevineNoble :: String -> String -> Int -> IO Grapevine
 grapevineNoble king name port = do
   let [host, seedPort] = splitOn ":" king
   gv <- newGrapevine (Just name) port
-  addrInfo <- getAddrInfo Nothing (Just host) (Just seedPort)
+  addrInfo <- getAddrInfo (Just (defaultHints { addrFamily=AF_INET }))
+                (Just host)
+                (Just seedPort)
   outSock <- reuseMyPort gv
   connect outSock (addrAddress $ head addrInfo)
   h <- socketToHandle outSock ReadWriteMode

--- a/dfinity-gossip.cabal
+++ b/dfinity-gossip.cabal
@@ -57,3 +57,27 @@ test-suite kautz-unit-tests
   ghc-options:
     -O2
     -Wall
+
+executable example
+  default-language:
+    Haskell2010
+  main-is:
+    example.hs
+  other-modules:
+    Grapevine
+    Kautz
+  build-depends:
+    BoundedChan,
+    async,
+    base,
+    bytestring,
+    containers,
+    cryptohash,
+    iproute,
+    network,
+    safe,
+    split
+  ghc-options:
+    -O2
+    -Wall
+

--- a/example.hs
+++ b/example.hs
@@ -11,7 +11,7 @@ main = do
   let
     sz = 32
     names = show <$> [1..sz]
-  central <- grapevineKing "CENTRAL" 0
+  central <- grapevineKing 0
   gvs <- forConcurrently names $ \name -> grapevineNoble ("localhost:" ++ show (grapevinePort central)) name 0
   let
     waitForSz = do


### PR DESCRIPTION
- Added corresponding `executable` section to the cabal file 
- Fixed compile error (type of `Grapevine.grapevineKing` was wrong)
- Fixed occasional Network.Socket.connect  error (within `Grapevine.grapevineNoble`)
  by passing in a hint for AF_INET

- Note: this can now be run as `stack build`, followed by `stack exec --example`